### PR TITLE
Update to ECS Optimized Amazon Linux 2 ami's

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_ami" "ecs_ami" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-${var.ami_version}-amazon-ecs-optimized"]
+    values = ["amzn2-ami-ecs-hvm-${var.ami_version}"]
   }
 }
 


### PR DESCRIPTION
* ECS optimized Amazon Linux is being EOLed on April 15th
* https://aws.amazon.com/blogs/containers/amazon-ecs-optimized-amazon-linux-ami-end-of-life/