### PR TITLE
Remove reference to deprecated template_file function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A terraform module to provide ECS clusters in AWS.
 [![CircleCI](https://circleci.com/gh/terraform-community-modules/tf_aws_ecs.svg?style=svg)](https://circleci.com/gh/terraform-community-modules/tf_aws_ecs)
 
 
-This Module currently supports Terraform 0.10.x, but does not require it. If you use tfenv, this module contains a `.terraform-version` file which matches the version of Terraform we currently use to test with.
+This Module currently supports Terraform >=0.10.x, but does not require it. If you use tfenv, this module contains a `.terraform-version` file which matches the version of Terraform we currently use to test with.
 
 
 Module Input Variables
@@ -60,7 +60,7 @@ extra_tags = [
 - `registrator_memory_reservation` - The soft limit (in MiB) of memory to reserve for the container, defaults 20
 - `enable_agents` - Enable Consul Agent and Registrator tasks on each ECS Instance. Defaults to false
 - `spot_bid_price` - Use spot instances and request this bid price.  Note that with this option you risk your instances
-                     shutting down if the market price rises above your bid price. 
+                     shutting down if the market price rises above your bid price.
 - `enabled_metrics` - A list of metrics to collect.
 
 Usage
@@ -81,7 +81,7 @@ module "ecs-cluster" {
 
 In order to start the Consul/Registrator task in ECS, you'll need to pass in a consul config into the `additional_user_data_script` script parameter.  For example, you might pass something like this:
 
-Please note, this module will try to mount `/etc/consul/` into `/consul/config` in the container and assumes that the consul config lives under `/etc/consul` on the docker host.  
+Please note, this module will try to mount `/etc/consul/` into `/consul/config` in the container and assumes that the consul config lives under `/etc/consul` on the docker host.
 
 ```Shell
 /bin/mkdir -p /etc/consul
@@ -102,24 +102,20 @@ CONSUL
 
 ```hcl
 
-data "template_file" "ecs_consul_agent_json" {
-  template = "${file("ecs_consul_agent.json.sh")}"
-
-  vars {
-    datacenter = "infra-services"
-  }
-}
-
 module "ecs-cluster" {
   source                      = "github.com/terraform-community-modules/tf_aws_ecs"
   name                        = "infra-services"
   servers                     = 1
   subnet_id                   = ["subnet-6e101446"]
   vpc_id                      = "vpc-99e73dfc"
-  additional_user_data_script = "${data.template_file.ecs_consul_agent_json.rendered}"
+  additional_user_data_script = templatefile(
+    "${file("ecs_consul_agent.json.sh")}",
+    {
+      datacenter = "infra-services"
+    }
+  )
   enable_agents               = true
 }
-
 
 ```
 
@@ -129,7 +125,7 @@ Outputs
 
 - `cluster_id` - _(String)_ ECS Cluster id for use in ECS task and service definitions.
 - `cluster_name` - (String) ECS Cluster name that can be used for CloudWatch app autoscaling policy resource_id.
-- `autoscaling_group` _(Map)_ A map with keys `id`, `name`, and `arn` of the `aws_autoscaling_group` created.  
+- `autoscaling_group` _(Map)_ A map with keys `id`, `name`, and `arn` of the `aws_autoscaling_group` created.
 - `iam_role` _(Map)_ A map with keys `arn` and `name` of the `iam_role` created.
 - `security_group` _(Map)_ A map with keys `id`, `name`, and `arn` of the `aws_security_group` created.
 

--- a/iam.tf
+++ b/iam.tf
@@ -76,7 +76,7 @@ resource "aws_iam_policy" "custom_ecs_policy" {
 
 resource "aws_iam_policy_attachment" "attach_ecs" {
   name       = "ecs-attachment"
-  roles      = [ aws_iam_role.ecs_role.name ]
+  roles      = [aws_iam_role.ecs_role.name]
   policy_arn = element(concat(aws_iam_policy.ecs_policy.*.arn, aws_iam_policy.custom_ecs_policy.*.arn), 0)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,13 @@ variable "additional_user_data_script" {
 
 variable "allowed_cidr_blocks" {
   default     = ["0.0.0.0/0"]
-  type        = list
+  type        = list(any)
   description = "List of subnets to allow into the ECS Security Group. Defaults to ['0.0.0.0/0']"
 }
 
 variable "allowed_egress_cidr_blocks" {
   default     = ["0.0.0.0/0"]
-  type        = list
+  type        = list(any)
   description = "List of subnets to allow out of the ECS Security Group. Defaults to ['0.0.0.0/0']"
 }
 
@@ -62,7 +62,7 @@ variable "ebs_block_device" {
 }
 
 variable "extra_tags" {
-  type    = list
+  type    = list(any)
   default = []
 }
 
@@ -96,7 +96,7 @@ variable "key_name" {
 }
 
 variable "load_balancers" {
-  type        = list
+  type        = list(any)
   default     = []
   description = "A list of elastic load balancer names to add to the autoscaling group names. Only valid for classic load balancers."
 }
@@ -135,7 +135,7 @@ variable "registrator_memory_reservation" {
 }
 
 variable "security_group_ids" {
-  type        = list
+  type        = list(any)
   description = "A list of Security group IDs to apply to the launch configuration"
   default     = []
 }
@@ -151,7 +151,7 @@ variable "spot_bid_price" {
 }
 
 variable "subnet_id" {
-  type        = list
+  type        = list(any)
   description = "The AWS Subnet ID in which you want to delpoy your instances"
 }
 
@@ -170,7 +170,7 @@ variable "vpc_id" {
 
 variable "enabled_metrics" {
   description = "A list of metrics to collect"
-  type        = list
+  type        = list(any)
   default     = []
 }
 


### PR DESCRIPTION
**Why?**
This Terraform module is reliant upon the [template provider](https://registry.terraform.io/providers/hashicorp/template/latest), which means it cannot be installed into projects on more modern macOS machines running on arm64 architecture as there is no suitable package available for that chipset.

**What changed?**
I have updated any references to the old module to use the built-in [templatefile](https://developer.hashicorp.com/terraform/language/functions/templatefile) function instead.

This does mean the minimum required version of TF is bumped from 0.10.0 to 0.12.0 but that shouldn't affect anything dxw are using. 

I have also linted and formatted the Terraform files using `terraform fmt` and `terraform validate` is successful.