### PR TITLE
Specify the AMI of EC2 instances

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -34,8 +34,8 @@ EOF
 resource "aws_iam_policy" "ecs_policy" {
   name_prefix = replace(format("%.102s", replace("tf-ECSInPol-${var.name}-", "_", "-")), "/\\s/", "-")
   description = "A terraform created policy for ECS"
-  path        = var.iam_path
-  count       = length(var.custom_iam_policy) > 0 ? 0 : 1
+  path = var.iam_path
+  count = length(var.custom_iam_policy) > 0 ? 0 : 1
 
   policy = <<EOF
 {

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  ami = var.ami != "" ? "${var.ami}${var.ami_version}" : "al2023-ami-ecs-hvm-${var.ami_version}"
+}

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_ami" "ecs_ami" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-ecs-hvm-${var.ami_version}"]
+    values = [local.ami]
   }
 
   filter {

--- a/variables.tf
+++ b/variables.tf
@@ -15,11 +15,13 @@ variable "allowed_egress_cidr_blocks" {
 }
 
 variable "ami" {
-  default = ""
+  description = "Name of a specific AMI to use"
+  default     = ""
 }
 
 variable "ami_version" {
-  default = "*"
+  description = "Specify a version of the AMI"
+  default     = "*"
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
The `var.ami` has always been defined but never used, this change simply allows us to specify a value which will be set instead of the default `al2023-ami-ecs-hvm-` AMI